### PR TITLE
chore(pr): add pr template in .github

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Changes
+_List Changes Introduced by this PR_
+1. Item 1
+2. Item 2
+
+## Purpose
+_Describe the problem or feature._
+
+## Approach
+_How does this change address the problem?_
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
+
+_If this closes an issue, reference the issue here. If it doesn't, remove this line_
+Closes #000


### PR DESCRIPTION
## Changes
1. Create a PR template in github folder

## Purpose
Automatically generate PR template when a developer starts a PR request

## Approach
The developer does not need to manually type the PR template when making a PR request

## Learning
https://github.com/Shift3/standards-and-practices/blob/main/standards/pull-request-template.md

Closes #15 