### PR TITLE
feat(server): create api call to get random caption

### DIFF
--- a/server/routes/caption.route.js
+++ b/server/routes/caption.route.js
@@ -47,3 +47,27 @@ captionRouter.delete('/delete-caption/:id', (req,res) => {
     .catch(err => res.status(500).json(err))
 
 })
+
+
+captionRouter.get('/random-caption', (req,res) => {
+    CaptionModel.aggregate([
+        {$sample: { 
+            size: 1 // grabs how many documents we will get 
+        }}
+    ])
+    .then(data => res.json(data))
+    .catch(err => res.status(500).json(err))
+})
+
+
+//Another way to get random document(caption) from db
+
+// captionRouter.get('/random-caption', (req,res) => {
+//     CaptionModel.count().exec(function(err, count){
+//         let random = Math.floor(Math.random() * count);
+
+//         CaptionModel.findOne().skip(random).exec()
+//         .then(data => res.json(data))
+//         .catch(err => res.status(500).json(err))
+//     })
+// })


### PR DESCRIPTION
## Changes
1. Add a get api call to get a random document from db
2. Use aggregation pipeline for better performance

## Purpose
- Create a random generator call from backend and will connect to browser later

## Approach
- Make an API call to get a random caption from db

## Learning

https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/#pipe._S_sample
https://stackoverflow.com/questions/14644545/random-document-from-a-collection-in-mongoose

Closes #28 
