### PR TITLE
feat(client/captionspage) Add styling to captions page edit and delet…

### DIFF
--- a/client/caption/components/caption.css
+++ b/client/caption/components/caption.css
@@ -134,10 +134,20 @@ tr, th{
     width: 55%;
     height: 80vh;
     border-radius: 20px;
-
+    overflow-x: scroll;
      
   
   }
+
+  @media (max-width: 600px) {
+
+    .table-container { 
+        width: 100% !important;
+        overflow-x: scroll; 
+    }
+
+   
+}
   
 
 /* Modal Content */
@@ -160,4 +170,30 @@ tr, th{
       height: 100vh;
   } */
 
+  .edit-btn{
+    font-family: 'Roboto' sans-serif;
+    font-size: 16px;
+    opacity: 1;
+    border: none;
+    border-radius: 8px;
+    height: 30px;
+    width: 50px;
+    color: rgb(26, 26, 26);
+    background-color: #d353f3f6;
+    margin: 10px;
+    
+  }
+
+  .delete-btn{
+    font-family: 'Roboto' sans-serif;
+    font-size: 16px;
+    opacity: 1;
+    border: none;
+    border-radius: 8px;
+    height: 30px;
+    width: 55px;
+    color: rgb(255, 255, 255);
+    background-color: #fd5473f6;
+    padding-right: 15px;
+  }
   

--- a/client/caption/services/all-captions.js
+++ b/client/caption/services/all-captions.js
@@ -17,6 +17,9 @@ function displayAllCaptions(cb1, cb2) {
             editButton.innerHTML = "Edit"
             deleteButton.innerHTML = "Delete"
 
+            editButton.className = "edit-btn"
+            deleteButton.className = "delete-btn"
+
             deleteButton.addEventListener('click', () => {
 
                 //callback

--- a/client/caption/services/all-captions.js
+++ b/client/caption/services/all-captions.js
@@ -48,8 +48,8 @@ function displayAllCaptions(cb1, cb2) {
                     console.log('I Saved');
                     cellTopText.setAttribute('contenteditable', 'false');
                     cellBottomText.setAttribute('contenteditable', 'false');
-                    cellTopText.style.backgroundColor = 'white'
-                    cellBottomText.style.backgroundColor = 'white'
+                    cellTopText.style.backgroundColor = '#fddaff'
+                    cellBottomText.style.backgroundColor = '#fddaff'
                     editButton.innerHTML = 'Edit'
                     editButton.style.background = 'Green'
 


### PR DESCRIPTION
…e buttons and add a horizontal scrollbar to the captions page when minimizing screen

## Changes
_List Changes Introduced by this PR_
1. Stylized the edit and delete buttons in the captions page (rounded corners and color backgrounds)
2. added a horizontal scrollbar when the captions page is minimized


## Purpose
To match the buttons to the rest of the meme generator webpage. The scrollbar was added to have to user be able to minimize the window and still be able to see the full captions page

## Approach
_How does this change address the problem?_

## Learning
With the help of Gichelle, we were able to call out the class names in css with grabbing the javascript id for the buttons.

For the scroll bar I used this website to add a horizontal scrollbar when minimizing the window.
https://www.studytonight.com/post/how-to-make-table-horizontally-scrollable-for-small-screen-size

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #74 
