### PR TITLE
feat(client/captions) add active link to captions page to show the…

### DIFF
--- a/client/caption/components/caption.html
+++ b/client/caption/components/caption.html
@@ -43,10 +43,10 @@
             <div class="collapse navbar-collapse  justify-content-end text-center" id="navbarNav">
                 <ul class="navbar-nav topnav-right justify-content-end">
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" href="../../index.html">Home</a>
+                        <a class="nav-link " aria-current="page" href="../../index.html">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="./caption.html">Captions</a>
+                        <a class="nav-link active" href="./caption.html">Captions</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
… active page in white text

## Changes
_List Changes Introduced by this PR_
1. changed active link to captions page in caption.html


## Purpose
active link/tab now shows as captions page in captions.html

## Approach
The problem was when the user was on the captions page, the captions tab appeared in gray text and home page showed as active tab. The solution was just to go to the caption.html and change the nav-link of captions to active.

## Learning
noticed on the index.html that the nav-link showed as active and on the caption.html as well. Just changed the nav-link for the captions tab to active

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #78
