### PR TITLE
ref(api): change baseUrl

### DIFF
--- a/client/apps/services/api.service.js
+++ b/client/apps/services/api.service.js
@@ -1,5 +1,5 @@
 export const apiService = ({
-    baseUrl: 'http://localhost:3000/api/',
+    baseUrl: location.origin.includes('localhost') ? 'http://localhost:3000/api/' : '' + '/api/',
 
     get: function(url) {
         return fetch(this.baseUrl + url).then(res => res.json());


### PR DESCRIPTION
## Changes
1. add ternary condition that if an app is running on location.origin includes 'localhost', run at localhost:3000; else concatenate  '/api/'  string after the serialized Uri (meme-stack-generator.herokuapp.com)

## Purpose
When in production mode, the app should still be connected to DB and perform CRUD operations even if it is not connected to HTTP://localhost:3000

## Approach
Will allow users to create, read, update, delete and randomize captions without needing to connect to localhost

## Learning

-Debugging session with Vinson and Sirisha
- https://developer.mozilla.org/en-US/docs/Web/API/Location/origin

Closes #95 
